### PR TITLE
Add custom JSON parser

### DIFF
--- a/change/@microsoft-webpack-stats-differ-66ed6f79-baf6-4b53-9f91-e2787d16eb98.json
+++ b/change/@microsoft-webpack-stats-differ-66ed6f79-baf6-4b53-9f91-e2787d16eb98.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add custom JSON parser",
+  "packageName": "@microsoft/webpack-stats-differ",
+  "email": "rnjuguna@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-stats-differ/package.json
+++ b/packages/webpack-stats-differ/package.json
@@ -20,20 +20,24 @@
     "lib/**/*.d.ts"
   ],
   "dependencies": {
-    "matcher": "^3.0.0",
-    "multimatch": "^5.0.0",
+    "@microsoft/azure-artifact-storage": "*",
+    "@mixer/webpack-bundle-compare": "^0.1.0",
     "globby": "^11.0.2",
     "lodash": "^4.17.21",
-    "upath": "^2.0.1",
-    "@mixer/webpack-bundle-compare": "^0.1.0",
-    "@microsoft/azure-artifact-storage": "*"
+    "matcher": "^3.0.0",
+    "multimatch": "^5.0.0",
+    "stream-chain": "^2.2.5",
+    "stream-json": "^1.7.5",
+    "upath": "^2.0.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-typescript": "^7.12.1",
     "@types/jest": "^26.0.15",
+    "@types/webpack": "^4.41.25",
+    "@types/stream-chain": "^2.0.1",
+    "@types/stream-json": "^1.7.3",
     "jest": "^26.6.3",
-    "typescript": "^4.2.2",
-    "@types/webpack": "^4.41.25"
+    "typescript": "^4.2.2"
   }
 }

--- a/packages/webpack-stats-differ/src/customJsonParser.ts
+++ b/packages/webpack-stats-differ/src/customJsonParser.ts
@@ -1,5 +1,4 @@
 import * as fs from "fs";
-import * as zlib from "zlib";
 import { chain } from 'stream-chain';
 import { parser } from 'stream-json';
 import { streamObject } from 'stream-json/streamers/StreamObject';
@@ -10,7 +9,6 @@ export const customJsonParser = (filePath: string): Promise<{ [key: string]: any
         const result: { [key:string]: any } = {}
         const pipeline = chain([
             fs.createReadStream(filePath),
-            zlib.createGunzip(),
             parser(),
             streamObject(),
         ]);

--- a/packages/webpack-stats-differ/src/customJsonParser.ts
+++ b/packages/webpack-stats-differ/src/customJsonParser.ts
@@ -1,0 +1,27 @@
+import * as fs from "fs";
+import * as zlib from "zlib";
+import { chain } from 'stream-chain';
+import { parser } from 'stream-json';
+import { streamObject } from 'stream-json/streamers/StreamObject';
+
+
+export const customJsonParser = (filePath: string): Promise<{ [key: string]: any }> => {
+    return new Promise((resolve, reject) => {
+        const result: { [key:string]: any } = {}
+        const pipeline = chain([
+            fs.createReadStream(filePath),
+            zlib.createGunzip(),
+            parser(),
+            streamObject(),
+        ]);
+        pipeline.on('data', (data) => {
+            result[data.key] = data.value;
+        })
+        pipeline.on('end', () => {
+            resolve(result);
+        })
+        pipeline.on('error', (err: any) => {
+            reject(err);
+        })
+    })
+}

--- a/packages/webpack-stats-differ/src/diff.ts
+++ b/packages/webpack-stats-differ/src/diff.ts
@@ -14,6 +14,7 @@ export {
   FileDiffResults,
 } from "./diffAssets";
 import { generateComparisonAddress } from "./comparisonAddress";
+import { customJsonParser } from "./customJsonParser";
 
 /**
  * Calculates the diff between two sets of bundle stats
@@ -160,9 +161,8 @@ const getRemoteArtifactsManifest = async (
 const getWebpackStatJSON = async (
   filePath: string
 ): Promise<WebpackStatsJson> => {
-  const data = await fs.promises.readFile(filePath, { encoding: "utf-8" });
   try {
-    const parsed: WebpackStatsJson = JSON.parse(data);
+    const parsed: WebpackStatsJson = customJsonParser(filePath) as unknown as WebpackStatsJson;
     return parsed;
   } catch (e: unknown) {
     throw new Error(`Cannot parse webpack state file ${filePath}: ${e}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,6 +1588,21 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
+"@types/stream-chain@*", "@types/stream-chain@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/stream-chain/-/stream-chain-2.0.1.tgz#4d3cc47a32609878bc188de0bae420bcfd3bf1f5"
+  integrity sha512-D+Id9XpcBpampptkegH7WMsEk6fUdf9LlCIX7UhLydILsqDin4L0QT7ryJR0oycwC7OqohIzdfcMHVZ34ezNGg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/stream-json@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@types/stream-json/-/stream-json-1.7.3.tgz#5596405be23c7db1b6fb9cb977b942b9e1d219df"
+  integrity sha512-Jqsyq5VPOTWorvEmzWhEWH5tJnHA+bB8vt/Zzb11vSDj8esfSHDMj2rbVjP0mfJQzl3YBJSXBBq08iiyaBK3KA==
+  dependencies:
+    "@types/node" "*"
+    "@types/stream-chain" "*"
+
 "@types/tapable@*":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
@@ -5326,6 +5341,18 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+stream-chain@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.2.5.tgz#b30967e8f14ee033c5b9a19bbe8a2cba90ba0d09"
+  integrity sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==
+
+stream-json@^1.7.5:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-1.7.5.tgz#2ff0563011f22cea4f6a28dbfc0344a53c761fe4"
+  integrity sha512-NSkoVduGakxZ8a+pTPUlcGEeAGQpWL9rKJhOFCV+J/QtdQUEU5vtBgVg6eJXn8JB8RZvpbJWZGvXkhz70MLWoA==
+  dependencies:
+    stream-chain "^2.2.5"
 
 strict-uri-encode@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The native node JSON parser has a limit of 512MB which we are hitting for certain bundlestats.json files. Using this custom parser we can safely parse JSON objects exceeding that limit