### PR TITLE
Add a regex to extract suiteux-shell bundles assets names

### DIFF
--- a/packages/webpack-stats-differ/package.json
+++ b/packages/webpack-stats-differ/package.json
@@ -27,8 +27,7 @@
     "matcher": "^3.0.0",
     "multimatch": "^5.0.0",
     "stream-chain": "^2.2.5",
-    "stream-json": "^1.7.5",
-    "upath": "^2.0.1"
+    "stream-json": "^1.7.5"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.12.1",

--- a/packages/webpack-stats-differ/src/getFriendlyAssetName.ts
+++ b/packages/webpack-stats-differ/src/getFriendlyAssetName.ts
@@ -61,7 +61,7 @@ export const removeHashFromName = (name: string): string => {
     const cleanSecondPart =
     secondDotPart && // Check if secondDotPart is truthy
     hashRegex.test(secondDotPart) // If it's truthy, check if it matches the hashRegex
-      ? secondDotPart + secondDotPart.replace(hashRegex, "") // If it matches, concatenate secondDotPart with the matched pattern removed from it using the replace() method
+      ? secondDotPart.replace(hashRegex, "") // If it matches, set the matched pattern removed from it using the replace() method
       : thirdDotPart // If it doesn't match, check if thirdDotPart is truthy
       ? secondDotPart + "." + thirdDotPart.replace(hashRegex, "") // If it's truthy, concatenate secondDotPart with a period and thirdDotPart with any matched pattern in thirdDotPart replaced with an empty string
       : secondDotPart; // If neither condition is met, set cleanSecondPart to secondDotPart

--- a/packages/webpack-stats-differ/src/getFriendlyAssetName.ts
+++ b/packages/webpack-stats-differ/src/getFriendlyAssetName.ts
@@ -2,6 +2,7 @@ import { identity } from "lodash/fp";
 import { Stats } from "webpack";
 import { WebpackAssetStat } from "./diffAssets";
 import * as upath from "upath";
+import { suiteUxAssetNameRegex } from "./matchesPattern";
 
 export type Asset = Exclude<Stats.ToJsonOutput["assets"], undefined>[number];
 
@@ -22,6 +23,10 @@ export function getFriendlyAssetName(
 ): string {
   // First try removing the hash manually from the file name.
   const name = asset.name;
+
+  let match = asset.name.match(suiteUxAssetNameRegex);
+  if (match) return match[1];
+
   const nameWithoutHash = removeHashFromName(name);
   if (nameWithoutHash !== name) {
     return nameWithoutHash;

--- a/packages/webpack-stats-differ/src/getFriendlyAssetName.ts
+++ b/packages/webpack-stats-differ/src/getFriendlyAssetName.ts
@@ -1,6 +1,5 @@
 import { Stats } from "webpack";
 import { WebpackAssetStat } from "./diffAssets";
-import * as upath from "upath";
 
 export type Asset = Exclude<Stats.ToJsonOutput["assets"], undefined>[number];
 
@@ -21,9 +20,9 @@ export function getFriendlyAssetName(
 ): string {
   // First try removing the hash manually from the file name.
   const name = asset.name;
-  const modifiedFileName = cleanFileName(name);
-  if (modifiedFileName !== name) {
-    return modifiedFileName;
+  const nameWithoutHash = removeHashFromName(name);
+  if (nameWithoutHash !== name) {
+    return nameWithoutHash;
   }
 
   // Try using the chunk names from the asset data instead.
@@ -36,12 +35,7 @@ export function getFriendlyAssetName(
   return name;
 }
 
-const removeHashFromName = (name: string): string => {
-  return name.replace(/([_.][a-z0-9]{20})(?:\b)/, "");
-};
-
-const cleanFileName = (name: string): string => {
-  const fileParts = upath.parse(name);
-  const baseName = fileParts.name;
-  return removeHashFromName(baseName) + fileParts.ext;
+//Removes a hash from a given filename and returns the base name
+export const removeHashFromName = (name: string): string => {
+  return name.replace(/^.*[\/]|([_.][a-z0-9]{20})(?:\b)/g, "");
 };

--- a/packages/webpack-stats-differ/src/getFriendlyAssetName.ts
+++ b/packages/webpack-stats-differ/src/getFriendlyAssetName.ts
@@ -1,4 +1,3 @@
-import { identity } from "lodash/fp";
 import { Stats } from "webpack";
 import { WebpackAssetStat } from "./diffAssets";
 import * as upath from "upath";

--- a/packages/webpack-stats-differ/src/getFriendlyAssetName.ts
+++ b/packages/webpack-stats-differ/src/getFriendlyAssetName.ts
@@ -22,9 +22,9 @@ export function getFriendlyAssetName(
 ): string {
   // First try removing the hash manually from the file name.
   const name = asset.name;
-  const nameWithoutHash = removeHashFromName(name);
-  if (nameWithoutHash !== name) {
-    return nameWithoutHash;
+  const modifiedFileName = cleanFileName(name);
+  if (modifiedFileName !== name) {
+    return modifiedFileName;
   }
 
   // Try using the chunk names from the asset data instead.
@@ -37,48 +37,12 @@ export function getFriendlyAssetName(
   return name;
 }
 
-const hashRegex = /_([a-z0-9]{20})/;
+const removeHashFromName = (name: string): string => {
+  return name.replace(/([_.][a-z0-9]{20})(?:\b)/, "");
+};
 
-// TODO(mapol): We need a better way to identify a hash inside a filename
-// TODO(mapol): We need to make this function take into account the folder name. Once we do that we can remove the `ignoreDelveStringsFiles` function.
-export const removeHashFromName = (name: string): string => {
+const cleanFileName = (name: string): string => {
   const fileParts = upath.parse(name);
-  // We could have filenames like .d.ts or .js.map
-  const splitByDotPart = fileParts.name.split(".");
-  const firstNamePart = splitByDotPart[0];
-  const secondDotPart = splitByDotPart[1];
-  const thirdDotPart = splitByDotPart[2];
-  // Remove hash
-  const otherParts = firstNamePart.split("_");
-
-  if (
-    otherParts.length === 1 ||
-    otherParts[otherParts.length - 1].length !== 20
-  ) {
-    // Search uses a hash in the secondDotPart e.g. search_init.min_7ba0dc2ea2246e82e8a5.js
-    // Oneshell uses a hash in the fourth part e.g. suiteux.shell.bootstrapper.d5a8a72572eca5ebbdd9.js
-
-    const cleanSecondPart =
-    secondDotPart && // Check if secondDotPart is truthy
-    hashRegex.test(secondDotPart) // If it's truthy, check if it matches the hashRegex
-      ? secondDotPart.replace(hashRegex, "") // If it matches, set the matched pattern removed from it using the replace() method
-      : thirdDotPart // If it doesn't match, check if thirdDotPart is truthy
-      ? secondDotPart + "." + thirdDotPart.replace(hashRegex, "") // If it's truthy, concatenate secondDotPart with a period and thirdDotPart with any matched pattern in thirdDotPart replaced with an empty string
-      : secondDotPart; // If neither condition is met, set cleanSecondPart to secondDotPart
-
-    return (
-      [
-        otherParts.join("_"),
-        cleanSecondPart, 
-      ]
-        .filter(identity)
-        .join(".") + fileParts.ext
-    );
-  }
-
-  return (
-    [otherParts.slice(0, -1).join("_"), secondDotPart]
-      .filter(identity)
-      .join(".") + fileParts.ext
-  );
+  const baseName = fileParts.name;
+  return removeHashFromName(baseName) + fileParts.ext;
 };

--- a/packages/webpack-stats-differ/src/matchesPattern.ts
+++ b/packages/webpack-stats-differ/src/matchesPattern.ts
@@ -4,5 +4,3 @@ export const matchesPattern = (
   filter: string | string[] | undefined,
   input: string
 ) => (filter ? isMatch(input, filter) : true);
-
-export const suiteUxAssetNameRegex = /suiteux\.shell\.([\w\d\-\_]*)\.?[\w\d]*\.js$/i;

--- a/packages/webpack-stats-differ/src/matchesPattern.ts
+++ b/packages/webpack-stats-differ/src/matchesPattern.ts
@@ -4,3 +4,5 @@ export const matchesPattern = (
   filter: string | string[] | undefined,
   input: string
 ) => (filter ? isMatch(input, filter) : true);
+
+export const suiteUxAssetNameRegex = /suiteux\.shell\.([\w\d\-\_]*)\.?[\w\d]*\.js$/i;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5776,11 +5776,6 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-upath@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-2.0.1.tgz#50c73dea68d6f6b990f51d279ce6081665d61a8b"
-  integrity sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==
-
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"


### PR DESCRIPTION
![size-bot-error](https://user-images.githubusercontent.com/19971639/235691172-2d2aa6eb-ea8f-4a42-93fd-cc2232429c2b.png)

This PR fixes above error.  

The error is happening because the current implementation truncates the assets names of suiteux-shell bundles stats.