### PR TITLE
Add support for using workers for parallelization

### DIFF
--- a/change/@microsoft-webpack-stats-differ-57b453af-1072-458d-af63-4fb1378a60eb.json
+++ b/change/@microsoft-webpack-stats-differ-57b453af-1072-458d-af63-4fb1378a60eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for using workers for parallelization",
+  "packageName": "@microsoft/webpack-stats-differ",
+  "email": "ronakjain.public@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-stats-differ/src/generateDiffsAsync.ts
+++ b/packages/webpack-stats-differ/src/generateDiffsAsync.ts
@@ -1,0 +1,109 @@
+import { isMainThread, parentPort } from "worker_threads";
+import type {
+  FileDiffResultWithComparisonToolUrl,
+  FileDiffResult,
+  FileToDiffDescriptor,
+  WebpackStatsJson,
+} from "./diffAssets";
+import { diffAssets } from "./diffAssets";
+import { FilePair } from "./pairFiles";
+import { customJsonParser } from "./customJsonParser";
+
+const getWebpackStatJSON = async (
+  filePath: string
+): Promise<WebpackStatsJson> => {
+  try {
+    const parsed: WebpackStatsJson = (customJsonParser(
+      filePath
+    ) as unknown) as WebpackStatsJson;
+    return parsed;
+  } catch (e: unknown) {
+    throw new Error(`Cannot parse webpack state file ${filePath}: ${e}`);
+  }
+};
+
+export type GetFileDiffOptions = {
+  pair: FilePair | null;
+  filter?: string | string[];
+};
+
+export type GenerateDiffAsyncResult =
+  | {
+      type: "changed";
+      result: FileDiffResultWithComparisonToolUrl;
+    }
+  | {
+      type: "added";
+      result: FileDiffResult;
+    }
+  | {
+      type: "removed";
+      result: FileToDiffDescriptor;
+    }
+  | {
+      type: "error";
+      result: string;
+    };
+
+export const getFileDiffResult = async ({
+  pair,
+  filter,
+}: GetFileDiffOptions): Promise<GenerateDiffAsyncResult> => {
+  if (!pair) {
+    return {
+      type: "error",
+      result: "baseline and candidate not found",
+    };
+  }
+  if (pair.baseline && pair.candidate) {
+    try {
+      const [parsedBase, parsedCandidate] = await Promise.all(
+        [pair.baseline, pair.candidate].map(getWebpackStatJSON)
+      );
+      const diffResult = diffAssets(parsedBase, parsedCandidate, filter);
+      return {
+        type: "changed",
+        result: {
+          name: pair.name,
+          diffStats: diffResult,
+        },
+      };
+    } catch (e) {
+      return {
+        type: "error",
+        result: e && typeof e.toString === "function" ? e.toString() : "",
+      };
+    }
+  } else if (pair.candidate) {
+    const parsedFile = await getWebpackStatJSON(pair.candidate);
+    return {
+      type: "added",
+      result: {
+        name: pair.name,
+        diffStats: diffAssets({ assets: [] }, parsedFile, filter),
+      },
+    };
+  } else if (pair.baseline) {
+    return {
+      type: "removed",
+      result: { name: pair.name, baselinePath: pair.baseline },
+    };
+  } else {
+    return {
+      type: "error",
+      result: "baseline and candidate not found",
+    };
+  }
+};
+
+if (!isMainThread) {
+  (async () => {
+    return new Promise(() => {
+      // No resolve in worker thread: The parent thread will postMessage and terminate the worker thread
+      parentPort?.on("message", async (data: GetFileDiffOptions) => {
+        const diffResult = await getFileDiffResult(data);
+        parentPort?.postMessage(diffResult);
+      });
+    });
+  })();
+}


### PR DESCRIPTION
When diffing 100+ bundles diffing can take 10+mins. Using workers should reduce this.

Mostly copied the worker logic from Mathieu's excellent pixel-buffer-diff-folders (https://github.com/p01/pixel-buffer-diff-folders/blob/979a9ebd4af9b412b1b713ff068239487b8542ed/src/index.ts#L86).

![image](https://github.com/microsoft/ardiffact/assets/2021979/08ded0ff-1c7a-4528-bdac-b7a1328b2e17)

168 seconds with workers vs 760 seconds without workers. (4-5x improvement)