### PR TITLE
Improved formatting of PR comment (detailed report)

### DIFF
--- a/change/@microsoft-webpack-stats-report-c083949c-7979-4478-b657-5eed8e90e879.json
+++ b/change/@microsoft-webpack-stats-report-c083949c-7979-4478-b657-5eed8e90e879.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improved report formatting",
+  "packageName": "@microsoft/webpack-stats-report",
+  "email": "71752651+unpervertedkid@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-stats-report/src/createReport.ts
+++ b/packages/webpack-stats-report/src/createReport.ts
@@ -23,7 +23,7 @@ const getPercentage = (reportAssetData: ReportAssetData) => {
   const percentage = (100 / refSize) * Math.abs(reportAssetData.diff);
 
   if (reportAssetData.isIncrease) {
-    return `+${percentage.toFixed(2)}%`;
+    return percentage > 20 ? `<b>+${percentage.toFixed(2)}%</b>` : `+${percentage.toFixed(2)}%`;
   }
 
   if (reportAssetData.isReduction) {
@@ -91,15 +91,19 @@ export function createDetailedReport(
   const comparisonLink = reportData.comparisonToolUrl
     ? `<a target="_blank" rel="noopener noreferrer" href="${reportData.comparisonToolUrl}">🔍</a>`
     : "";
+    const percentageChange = Math.floor((100 / reportData.totalSize) * Math.abs(reportData.totalDiff));
   const deltaSizeMessage = `${getReducedOrIncreased(
-    reportData.totalDiff,
-    minimumIncrease
-  )} total size by ${formatBytes(Math.abs(reportData.totalDiff))}`;
-  const totalSizeMessage = `Total size: ${formatBytes(reportData.totalSize)}`;
+    reportData.totalDiff
+  )} by <b>${percentageChange}%</b>(${formatBytes(Math.abs(reportData.totalDiff))})`;
+  const totalSizeMessage = `${formatBytes(reportData.totalSize)}`;
   const ownersMessage = reportData.ownedBy?.map((owner) => `@${owner}`).join(" ") || "";
-  const prefix = `<summary><span style="font-size: 16px">${reportData.name} ${comparisonLink}</span><br><ul><li>${deltaSizeMessage}</li><li>${totalSizeMessage}</li>${shouldAtMention(reportData,atMentionThreshold) ? `<li>${ownersMessage}</li>` : ``}</summary>`;
 
-  const header = "\n| Asset name | Size | Diff | |";
+  const prefix = `<summary><span style="font-size: 16px">  ${comparisonLink} ${reportData.name} ${deltaSizeMessage} to ${totalSizeMessage} ${shouldAtMention(reportData,atMentionThreshold) ? `${ownersMessage}` : ``}</span> </summary>`;
+  
+  
+  const shouldTableBeExpanded = percentageChange >= 20;
+
+  const header = "\n| Asset name | Size | Diff | Percentage change | ";
   const headerSeparator = "|---|---|---|---|";
 
   const rows = reportData.assets.map((reportAssetData) => {
@@ -112,7 +116,7 @@ export function createDetailedReport(
   });
 
   return `
-  <details>${[prefix, header, headerSeparator, ...rows].join(
+  <details ${shouldTableBeExpanded ? "open" : ""}>${[prefix, header, headerSeparator, ...rows].join(
     "\n"
   )}\n</details>`;
 }
@@ -145,12 +149,11 @@ export function createNoChangeReport(reportData: ReportData[]): string {
 }
 
 function getReducedOrIncreased(
-  diffSize: number,
-  minimumIncrease: number
+  diffSize: number
 ): string {
   return diffSize > 0
-    ? (diffSize > minimumIncrease ? "🔺&nbsp;" : "") + "Increased"
-    : "✅&nbsp;Reduced";
+    ? "increased"
+    : "reduced";
 }
 
 function formatBytes(bytes: number, decimals: number = 2): string {

--- a/packages/webpack-stats-report/src/createReport.ts
+++ b/packages/webpack-stats-report/src/createReport.ts
@@ -23,7 +23,7 @@ const getPercentage = (reportAssetData: ReportAssetData) => {
   const percentage = (100 / refSize) * Math.abs(reportAssetData.diff);
 
   if (reportAssetData.isIncrease) {
-    return percentage > 20 ? `<b>+${percentage.toFixed(2)}%</b>` : `+${percentage.toFixed(2)}%`;
+    return percentage > 5 ? `<b>+${percentage.toFixed(2)}%</b>` : `+${percentage.toFixed(2)}%`;
   }
 
   if (reportAssetData.isReduction) {
@@ -101,7 +101,7 @@ export function createDetailedReport(
   const prefix = `<summary><span style="font-size: 16px">  ${comparisonLink} ${reportData.name} ${deltaSizeMessage} to ${totalSizeMessage} ${shouldAtMention(reportData,atMentionThreshold) ? `${ownersMessage}` : ``}</span> </summary>`;
   
   
-  const shouldTableBeExpanded = percentageChange >= 20;
+  const shouldTableBeExpanded = percentageChange >= 5;
 
   const header = "\n| Asset name | Size | Diff | Percentage change | ";
   const headerSeparator = "|---|---|---|---|";


### PR DESCRIPTION
# Changes
## 1. Put the overall summary per package on a single line eg:

🔍 Feed-office-android increased by **12%**(5MB) to 45mb

instead of:

 Feed-office-android 🔍
* increased by 5 MB
* Total size 45 MB

## 2. Added "Percentage change" table heading

### Previously
| Asset name | Size | Diff |  | 
|---|---|---|---|

### Currently

| Asset name | Size | Diff | Percentage change | 
|---|---|---|---|
## 3. Bolding significant increases( >=5%)

| Asset name | Size | Diff | Percentage change | 
|---|---|---|---|
| <span style="">Asset A</span> | <span style="white-space: nowrap;">0.15 KB</span> | <span style="white-space: nowrap;">0.05 KB</span> | <span style="white-space: nowrap;"><b>+33.33%</b> 🔺</span> |
</details>


## 4. Expand the table by default for packages with a significant increase (>=5%)
 <details open><summary><span style="font-size: 16px">  <a target="_blank" rel="noopener noreferrer" href="https://example.com/compare/assetA">🔍</a> Package A  increased by <b>33%</b>(0.05 KB) to 0.15 KB </span> </summary>

| Asset name | Size | Diff | Percentage change | 
|---|---|---|---|
| <span style="">Asset A</span> | <span style="white-space: nowrap;">0.15 KB</span> | <span style="white-space: nowrap;">0.05 KB</span> | <span style="white-space: nowrap;"><b>+33.33%</b> 🔺</span> |
</details>

