### PR TITLE
Fixing percentage change for more accurate representations of changes

### DIFF
--- a/change/@microsoft-webpack-stats-differ-c3bddece-bed2-44bd-9a65-8d2ef74a8cd0.json
+++ b/change/@microsoft-webpack-stats-differ-c3bddece-bed2-44bd-9a65-8d2ef74a8cd0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "applying package updates",
+  "packageName": "@microsoft/webpack-stats-differ",
+  "email": "71752651+unpervertedkid@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-webpack-stats-differ-c3bddece-bed2-44bd-9a65-8d2ef74a8cd0.json
+++ b/change/@microsoft-webpack-stats-differ-c3bddece-bed2-44bd-9a65-8d2ef74a8cd0.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "applying package updates",
-  "packageName": "@microsoft/webpack-stats-differ",
-  "email": "71752651+unpervertedkid@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-webpack-stats-report-a18a492e-8402-4056-aaec-705652d30127.json
+++ b/change/@microsoft-webpack-stats-report-a18a492e-8402-4056-aaec-705652d30127.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix reporting of changes below 1%",
+  "packageName": "@microsoft/webpack-stats-report",
+  "email": "71752651+unpervertedkid@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-stats-report/src/createReport.ts
+++ b/packages/webpack-stats-report/src/createReport.ts
@@ -91,7 +91,9 @@ export function createDetailedReport(
   const comparisonLink = reportData.comparisonToolUrl
     ? `<a target="_blank" rel="noopener noreferrer" href="${reportData.comparisonToolUrl}">🔍</a>`
     : "";
-    const percentageChange = Math.floor((100 / reportData.totalSize) * Math.abs(reportData.totalDiff));
+    
+    const percentageChange = parseFloat(((Math.abs(reportData.totalDiff) / reportData.totalSize) * 100).toFixed(2));
+
   const deltaSizeMessage = `${getReducedOrIncreased(
     reportData.totalDiff
   )} by <b>${percentageChange}%</b>(${formatBytes(Math.abs(reportData.totalDiff))})`;


### PR DESCRIPTION
# Problem
Previously we floored the percentage change ie if its 12.65%, this was displayed as 12%.
However, for smaller changes, ie below 1%, this can be deceptive as this will show up as 0% changes.

# Solution
This PR updates the createDetailedReport function to display all percentage changes with two decimal places, regardless of their value.
This ensures that all percentage changes are displayed consistently with two decimal places, and allows for accurate checks on the percentage change value.