### PR TITLE
Update report formatting

### DIFF
--- a/change/@microsoft-webpack-stats-report-f96e659f-a8b8-42a9-8e48-d6da1d45eb29.json
+++ b/change/@microsoft-webpack-stats-report-f96e659f-a8b8-42a9-8e48-d6da1d45eb29.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update comment formatting",
+  "packageName": "@microsoft/webpack-stats-report",
+  "email": "ronakjain.public@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-stats-report/src/createReport.ts
+++ b/packages/webpack-stats-report/src/createReport.ts
@@ -88,14 +88,8 @@ export function createDetailedReport(
     : "";
 
   const percentageChange =
-    reportData.baselineSize === 0
-      ? 100
-      : parseFloat(
-          (
-            (Math.abs(reportData.totalDiff) / reportData.baselineSize) *
-            100
-          ).toFixed(2)
-        );
+    (reportData.baselineSize === 0
+      ? 100 : (Math.abs(reportData.totalDiff) / reportData.baselineSize) * 100).toFixed(2);
 
   const diffSign = getReducedOrIncreased(reportData.totalDiff);
   const diffFormatBytes = formatBytes(Math.abs(reportData.totalDiff));
@@ -104,9 +98,7 @@ export function createDetailedReport(
   const emoji = getEmojiForTotalAssetChange(isIncrease);
   const color = getTextColorForTotalAssetChange(isIncrease);
 
-  const deltaSizeMessage = `<span style="font-weight:bold;color:${color}">(${diffSign}${diffFormatBytes} | ${diffSign}${percentageChange.toFixed(
-    2
-  )}%)</span>`;
+  const deltaSizeMessage = `<span style="font-weight:bold;color:${color}">(${diffSign}${diffFormatBytes} | ${diffSign}${percentageChange}%)</span>`;
   const totalSizeMessage = `${formatBytes(reportData.totalSize)}`;
   const ownersMessage =
     reportData.ownedBy?.map((owner) => `@${owner}`).join(" ") || "";

--- a/packages/webpack-stats-report/src/createReport.ts
+++ b/packages/webpack-stats-report/src/createReport.ts
@@ -87,20 +87,24 @@ export function createDetailedReport(
     ? `<a target="_blank" rel="noopener noreferrer" href="${reportData.comparisonToolUrl}">🔍</a>`
     : "";
 
-  const percentageChange = reportData.baselineSize === 0 ? 100 : parseFloat(
-    ((Math.abs(reportData.totalDiff) / reportData.baselineSize) * 100).toFixed(2)
-  );
+  const percentageChange =
+    reportData.baselineSize === 0
+      ? 100
+      : parseFloat(
+          (
+            (Math.abs(reportData.totalDiff) / reportData.baselineSize) *
+            100
+          ).toFixed(2)
+        );
 
-  const diffSign = getReducedOrIncreased(
-    reportData.totalDiff
-  );
+  const diffSign = getReducedOrIncreased(reportData.totalDiff);
 
-  const diffFormatBytes = formatBytes(
-    Math.abs(reportData.totalDiff)
-  )
+  const diffFormatBytes = formatBytes(Math.abs(reportData.totalDiff));
 
-  const emoji = getEmojiForTotalAssetChange(reportData.totalDiff > 0);
-  const color = getTextColorForTotalAssetChange(reportData.totalDiff > 0);
+  const isIncrease = reportData.totalDiff > 0;
+
+  const emoji = getEmojiForTotalAssetChange(isIncrease);
+  const color = getTextColorForTotalAssetChange(isIncrease);
 
   const deltaSizeMessage = `<span style="font-weight:bold;color:${color}">(${diffSign}${diffFormatBytes} | ${diffSign}${percentageChange}%)</span>`;
   const totalSizeMessage = `${formatBytes(reportData.totalSize)}`;
@@ -113,8 +117,8 @@ export function createDetailedReport(
     shouldAtMention(reportData, atMentionThreshold) ? `${ownersMessage}` : ``
   }</span> </summary>`;
 
-
-  const header = "\n| Asset&nbsp;name | Size | Diff | Percentage&nbsp;change | ";
+  const header =
+    "\n| Asset&nbsp;name | Size | Diff | Percentage&nbsp;change | ";
   const headerSeparator = "|---|---|---|---|";
 
   const rows = reportData.assets.map((reportAssetData) => {
@@ -127,12 +131,9 @@ export function createDetailedReport(
   });
 
   return `
-  <details>${[
-    prefix,
-    header,
-    headerSeparator,
-    ...rows,
-  ].join("\n")}\n</details>`;
+  <details>${[prefix, header, headerSeparator, ...rows].join(
+    "\n"
+  )}\n</details>`;
 }
 
 export function createNoChangeReport(reportData: ReportData[]): string {
@@ -201,4 +202,3 @@ function getTextColorForTotalAssetChange(isIncrease: boolean): string {
     return "#00A36C";
   }
 }
-

--- a/packages/webpack-stats-report/src/createReport.ts
+++ b/packages/webpack-stats-report/src/createReport.ts
@@ -104,7 +104,9 @@ export function createDetailedReport(
   const emoji = getEmojiForTotalAssetChange(isIncrease);
   const color = getTextColorForTotalAssetChange(isIncrease);
 
-  const deltaSizeMessage = `<span style="font-weight:bold;color:${color}">(${diffSign}${diffFormatBytes} | ${diffSign}${percentageChange}%)</span>`;
+  const deltaSizeMessage = `<span style="font-weight:bold;color:${color}">(${diffSign}${diffFormatBytes} | ${diffSign}${percentageChange.toFixed(
+    2
+  )}%)</span>`;
   const totalSizeMessage = `${formatBytes(reportData.totalSize)}`;
   const ownersMessage =
     reportData.ownedBy?.map((owner) => `@${owner}`).join(" ") || "";
@@ -166,10 +168,10 @@ function getReducedOrIncreased(diffSize: number): string {
 }
 
 function formatBytes(bytes: number, decimals: number = 2): string {
-  const inKb = bytes / 1000;
+  const inKb = bytes / 1024;
   // &nbsp; instead of space to avoid line wrapping in table
-  if (inKb > 1000) {
-    return (inKb / 1000).toFixed(decimals) + "&nbsp;MB";
+  if (inKb > 1024) {
+    return (inKb / 1024).toFixed(decimals) + "&nbsp;MB";
   }
   return inKb.toFixed(decimals) + "&nbsp;KB";
 }

--- a/packages/webpack-stats-report/src/createReport.ts
+++ b/packages/webpack-stats-report/src/createReport.ts
@@ -109,9 +109,9 @@ export function createDetailedReport(
   const ownersMessage =
     reportData.ownedBy?.map((owner) => `@${owner}`).join(" ") || "";
 
-  const prefix = `<summary><span style="font-size: 16px">${emoji} ${comparisonLink} ${
+  const prefix = `<summary><span style="font-size: 16px">${emoji} ${
     reportData.name
-  } - ${totalSizeMessage} ${deltaSizeMessage} ${
+  } - ${totalSizeMessage} ${deltaSizeMessage} ${comparisonLink} ${
     shouldAtMention(reportData, atMentionThreshold) ? `${ownersMessage}` : ``
   }</span> </summary>`;
 

--- a/packages/webpack-stats-report/src/createReport.ts
+++ b/packages/webpack-stats-report/src/createReport.ts
@@ -98,9 +98,7 @@ export function createDetailedReport(
         );
 
   const diffSign = getReducedOrIncreased(reportData.totalDiff);
-
   const diffFormatBytes = formatBytes(Math.abs(reportData.totalDiff));
-
   const isIncrease = reportData.totalDiff > 0;
 
   const emoji = getEmojiForTotalAssetChange(isIncrease);

--- a/packages/webpack-stats-report/src/createReportData.ts
+++ b/packages/webpack-stats-report/src/createReportData.ts
@@ -7,9 +7,10 @@ export interface ReportData {
   name: string;
   totalDiff: number;
   totalSize: number;
+  baselineSize: number;
   assets: ReportAssetData[];
   comparisonToolUrl?: string;
-  ownedBy?: string[]
+  ownedBy?: string[];
 }
 
 export interface ReportAssetData {
@@ -26,7 +27,7 @@ export const createReportData = ({
   name,
   diffStats,
   comparisonToolUrl,
-  ownedBy
+  ownedBy,
 }: FileDiffResultWithComparisonToolUrl): ReportData => {
   const largestDiffFirst = (a: { diff: number }, b: { diff: number }) =>
     b.diff - a.diff;
@@ -35,6 +36,7 @@ export const createReportData = ({
     .map((asset) => ({
       name: asset.assetName,
       size: asset.candidateAssetSize,
+      baselineSize: asset.baselineAssetSize,
       diff: asset.sizeDiff,
       isIncrease: asset.isSizeIncrease,
       isReduction: asset.isSizeReduction,
@@ -50,6 +52,7 @@ export const createReportData = ({
     .map((asset) => ({
       name: asset.assetName,
       size: asset.candidateAssetSize,
+      baselineSize: asset.baselineAssetSize,
       diff: asset.sizeDiff,
       isIncrease: asset.isSizeIncrease,
       isReduction: asset.isSizeReduction,
@@ -62,6 +65,7 @@ export const createReportData = ({
     .map((asset) => ({
       name: asset.assetName,
       size: asset.candidateAssetSize,
+      baselineSize: asset.baselineAssetSize,
       diff: asset.sizeDiff,
       isIncrease: asset.isSizeIncrease,
       isReduction: asset.isSizeReduction,
@@ -72,12 +76,13 @@ export const createReportData = ({
 
   const unchanged = diffStats.unchangedStats.map((asset) => ({
     size: asset.candidateAssetSize,
+    baselineSize: asset.baselineAssetSize,
     diff: asset.sizeDiff,
   }));
 
   const assets = concat(added, changed, removed);
 
-  return {
+  const report = {
     name: getAppName(name),
     assets,
     totalDiff: assets.reduce(
@@ -87,9 +92,13 @@ export const createReportData = ({
     totalSize: unchanged
       .concat(assets)
       .reduce((totalSize, asset) => (totalSize += asset.size), 0),
+    baselineSize: unchanged
+      .concat(assets)
+      .reduce((totalSize, asset) => (totalSize += asset.baselineSize), 0),
     comparisonToolUrl,
-    ownedBy
+    ownedBy,
   };
+  return report;
 };
 
 function uppercaseFirst(appName: string): string {

--- a/packages/webpack-stats-report/src/createReportData.ts
+++ b/packages/webpack-stats-report/src/createReportData.ts
@@ -82,7 +82,7 @@ export const createReportData = ({
 
   const assets = concat(added, changed, removed);
 
-  const report = {
+  return {
     name: getAppName(name),
     assets,
     totalDiff: assets.reduce(
@@ -98,7 +98,6 @@ export const createReportData = ({
     comparisonToolUrl,
     ownedBy,
   };
-  return report;
 };
 
 function uppercaseFirst(appName: string): string {


### PR DESCRIPTION
This fixes various issues with the report formatting
- Too verbose, not clear at a glance which bundles have increased or decreased.
    - **Fix**: Removed all increased by/decreased by headers and changed to emoji, color style
- ADO Comment API sometimes errors as it hits max comment length for a single bundle diffs
   - **Fix**: Removed span style formatting for avoiding line wrap. Instead replaced spaces in byte formatting with non breaking space (& nbsp) to avoid line wraps. This reduces comment size.
- Percentage change was considering the new size as base for calculating percentage
   - **Fix** - percentage change now considers baseline size (in case it's a new bundle / baseline = 0 we report 100%)
- Keeping details open on large changes was leading to very long bundle comments
   - **Fix** - removed logic of keeping bundle open

![image](https://github.com/microsoft/ardiffact/assets/2021979/59287c81-afcb-4ff4-9dd5-340e7ed5be11)

