### PR TITLE
Restrict user delegation key expiry time to 7 days

### DIFF
--- a/change/@microsoft-azure-artifact-storage-8255911d-3eb9-4e0c-a989-8fba3b30ef67.json
+++ b/change/@microsoft-azure-artifact-storage-8255911d-3eb9-4e0c-a989-8fba3b30ef67.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update max expiry to 7 days",
+  "packageName": "@microsoft/azure-artifact-storage",
+  "email": "ronakjain.public@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-artifact-storage/src/discover.ts
+++ b/packages/azure-artifact-storage/src/discover.ts
@@ -58,7 +58,7 @@ async function generateArtifactSasTokens(
 ): Promise<RemoteArtifact[]> {
   const containerClient = createContainerClient(config);
   const startsOn = new Date();
-  const duration = 60 * 24 * 60 * 60 * 1000;
+  const duration = 6.99 * 24 * 60 * 60 * 1000; // 7 days - max timespan allowed
   const expires = new Date(startsOn.getTime() + duration);
   let userDelegationKey: ServiceGetUserDelegationKeyResponse | undefined;
   if (!config.storageKey) {


### PR DESCRIPTION
From - https://learn.microsoft.com/en-us/rest/api/storageservices/get-user-delegation-key#request-body maximum duration with user delegation key is 7 days