### PR TITLE
Memory Optimization for Webpack Stats Processing

### DIFF
--- a/change/@microsoft-webpack-stats-differ-ca7368e3-a75f-4edd-bdfe-9bd3259c6cdc.json
+++ b/change/@microsoft-webpack-stats-differ-ca7368e3-a75f-4edd-bdfe-9bd3259c6cdc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Implement streaming JSON parser to prevent heap memory errors",
+  "packageName": "@microsoft/webpack-stats-differ",
+  "email": "cheruiyotbryan@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Problem
Our webpack stats processor was encountering "JavaScript heap out of memory" errors when processing large stats files. The issue occurs because `JSON.parse()` loads the entire file into memory at once, which can exceed Node.js memory limits with large webpack stats files.

Error observed:
```
FATAL ERROR: MarkCompactCollector: young object promotion failed Allocation failed - JavaScript heap out of memory
```

### Solution
This PR implements a size-based approach to process webpack stats files:
- For small files (<100MB), the original `JSON.parse()` method is used for better performance
- For large files (≥100MB), a streaming JSON parser is used to process the file incrementally
- Added proper file access checks and improved error handling

### Dependencies Added
- `stream-json`: For streaming JSON parsing
- `stream-chain`: For creating processing pipelines

### Testing
Tested with:
- Small webpack stats files (<10MB)
- Medium webpack stats files (~50MB)
- Large webpack stats files (>200MB) that previously caused OOM errors

### Considerations
- The streaming approach maintains a constant memory footprint regardless of file size
- No changes to the API contract - all functions maintain their original signatures
- The threshold (100MB) can be adjusted based on performance testing

This change should resolve the heap out of memory errors we've been experiencing in our CI pipeline when processing large webpack stats files.