### PR TITLE
Reduce json parse threshold to 10MB

### DIFF
--- a/change/@microsoft-webpack-stats-differ-28b15af5-231f-4715-9695-f62620c4bf4e.json
+++ b/change/@microsoft-webpack-stats-differ-28b15af5-231f-4715-9695-f62620c4bf4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "reduce json parse threshold to 10MB",
+  "packageName": "@microsoft/webpack-stats-differ",
+  "email": "cheruiyotbryan@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-stats-differ/src/generateDiffsAsync.ts
+++ b/packages/webpack-stats-differ/src/generateDiffsAsync.ts
@@ -27,7 +27,7 @@ const getWebpackStatJSON = async (
   const fileSizeInMB = stats.size / (1024 * 1024);
 
   // For small files, use the regular JSON.parse method
-  if (fileSizeInMB < 100) {
+  if (fileSizeInMB < 10) {
     // Adjust threshold as needed
     try {
       const parsed: WebpackStatsJson = JSON.parse(


### PR DESCRIPTION
Adjust the threshold for JSON parsing to 10MB in the `getWebpackStatJSON` function.