### PR TITLE
Enable Target size and threshold for key assets

### DIFF
--- a/change/@microsoft-webpack-stats-differ-daf4ee41-78cf-4d3c-b403-01f496f786af.json
+++ b/change/@microsoft-webpack-stats-differ-daf4ee41-78cf-4d3c-b403-01f496f786af.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Enable target size and threshold for key assets",
+  "packageName": "@microsoft/webpack-stats-differ",
+  "email": "mathieu@p01.org",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-webpack-stats-report-9fb6316d-dab3-44f8-bf2e-241ceae691cc.json
+++ b/change/@microsoft-webpack-stats-report-9fb6316d-dab3-44f8-bf2e-241ceae691cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Enable target size and threshold for key assets",
+  "packageName": "@microsoft/webpack-stats-report",
+  "email": "mathieu@p01.org",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-stats-differ/package.json
+++ b/packages/webpack-stats-differ/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webpack-stats-differ",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": {

--- a/packages/webpack-stats-differ/src/diffAssets.ts
+++ b/packages/webpack-stats-differ/src/diffAssets.ts
@@ -43,6 +43,7 @@ interface ChangedStats {
 interface AssetStats {
   assetName: string;
   isKeyAsset: boolean,
+  hasTarget: boolean,
   candidateAssetSize: number;
   baselineAssetSize: number;
   isSizeReduction: boolean;
@@ -129,9 +130,8 @@ const diffWebpackAssets = ({ name, a, b }: Paired): AssetStats => {
   const isKeyAsset = flatternChunkNames.includes("⭐");
   // The format for key assets is
   // " ⭐ asseName" or " ⭐ assetName target threshold"
-  const [sizeA, threshold] = flatternChunkNames.replace(/^.*⭐ [^ ]+/, "").replace(/\n.*/, "").split(" ") ?? [a?.size ?? 0, SIGNIFICANT_CHANGE_THRESHOLD];
-
-//  const sizeA = a?.size ?? 0;
+  const [target, threshold] = flatternChunkNames.replace(/^.*⭐ [^ ]+/, "").replace(/\n.*/, "").split(" ").map(v => parseInt(v, 10)) ?? [undefined, SIGNIFICANT_CHANGE_THRESHOLD]; 
+  const sizeA = target !== undefined ? target : (a?.size ?? 0);
   const sizeB = b?.size ?? 0;
   const sizeDiff = sizeB - sizeA;
   const isSizeReduction = sizeDiff < 0;
@@ -142,6 +142,7 @@ const diffWebpackAssets = ({ name, a, b }: Paired): AssetStats => {
   return {
         assetName: name,
         isKeyAsset,
+        hasTarget: target !== undefined,
         sizeDiff: isSignificantDifference(sizeDiff, threshold) ? sizeDiff : 0,
         candidateAssetSize: sizeB,
         baselineAssetSize: sizeA,

--- a/packages/webpack-stats-report/package.json
+++ b/packages/webpack-stats-report/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webpack-stats-report",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": {

--- a/packages/webpack-stats-report/src/createReport.ts
+++ b/packages/webpack-stats-report/src/createReport.ts
@@ -72,7 +72,7 @@ const getDiffAttentionLevel = (
     }
     const refSize = reportAssetData.size - reportAssetData.diff;
     const percentage = (100 / refSize) * Math.abs(reportAssetData.diff);
-    if (percentage >= atMentionThreshold) {
+    if (percentage >= atMentionThreshold || (reportAssetData.hasTarget && reportAssetData.diff !== 0)) {
       if (reportAssetData.isKeyAsset) {
         diffAttentionLevel = "review";
         break;

--- a/packages/webpack-stats-report/src/createReportData.ts
+++ b/packages/webpack-stats-report/src/createReportData.ts
@@ -16,6 +16,7 @@ export interface ReportData {
 export interface ReportAssetData {
   name: string;
   isKeyAsset: boolean;
+  hasTarget: boolean;
   size: number;
   diff: number;
   isIncrease: boolean;
@@ -37,6 +38,7 @@ export const createReportData = ({
     .map((asset) => ({
       name: asset.assetName,
       isKeyAsset: asset.isKeyAsset,
+      hasTarget: asset.hasTarget,
       size: asset.candidateAssetSize,
       baselineSize: asset.baselineAssetSize,
       diff: asset.sizeDiff,
@@ -54,6 +56,7 @@ export const createReportData = ({
     .map((asset) => ({
       name: asset.assetName,
       isKeyAsset: asset.isKeyAsset,
+      hasTarget: asset.hasTarget,
       size: asset.candidateAssetSize,
       baselineSize: asset.baselineAssetSize,
       diff: asset.sizeDiff,
@@ -68,6 +71,7 @@ export const createReportData = ({
     .map((asset) => ({
       name: asset.assetName,
       isKeyAsset: asset.isKeyAsset,
+      hasTarget: asset.hasTarget,
       size: asset.candidateAssetSize,
       baselineSize: asset.baselineAssetSize,
       diff: asset.sizeDiff,


### PR DESCRIPTION
Take the input format `⭐ assetName` and the new `⭐ assetName target threshold` format into account to enable diffing candidate key assets against a target + threshold rather than their baseline version.  