### PR TITLE
Make explicit target and thershold optional

### DIFF
--- a/change/@microsoft-webpack-stats-differ-a889ac8a-6fb3-480f-8a50-6a00136dec9e.json
+++ b/change/@microsoft-webpack-stats-differ-a889ac8a-6fb3-480f-8a50-6a00136dec9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make explicit target and thershold optional",
+  "packageName": "@microsoft/webpack-stats-differ",
+  "email": "mathieu@p01.org",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-webpack-stats-report-bca95130-6b82-4958-a79c-bd70e1e7f8a3.json
+++ b/change/@microsoft-webpack-stats-report-bca95130-6b82-4958-a79c-bd70e1e7f8a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make explicit target and thershold optional",
+  "packageName": "@microsoft/webpack-stats-report",
+  "email": "mathieu@p01.org",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-stats-report/src/createReport.ts
+++ b/packages/webpack-stats-report/src/createReport.ts
@@ -72,7 +72,7 @@ const getDiffAttentionLevel = (
     }
     const refSize = reportAssetData.size - reportAssetData.diff;
     const percentage = (100 / refSize) * Math.abs(reportAssetData.diff);
-    if (percentage >= atMentionThreshold || (reportAssetData.hasTarget && reportAssetData.diff !== 0)) {
+    if (percentage >= atMentionThreshold || ((reportAssetData.hasTarget || reportAssetData.hasThreshold) && reportAssetData.diff !== 0)) {
       if (reportAssetData.isKeyAsset) {
         diffAttentionLevel = "review";
         break;

--- a/packages/webpack-stats-report/src/createReportData.ts
+++ b/packages/webpack-stats-report/src/createReportData.ts
@@ -17,6 +17,7 @@ export interface ReportAssetData {
   name: string;
   isKeyAsset: boolean;
   hasTarget: boolean;
+  hasThreshold: boolean;
   size: number;
   diff: number;
   isIncrease: boolean;
@@ -39,6 +40,7 @@ export const createReportData = ({
       name: asset.assetName,
       isKeyAsset: asset.isKeyAsset,
       hasTarget: asset.hasTarget,
+      hasThreshold: asset.hasThreshold,
       size: asset.candidateAssetSize,
       baselineSize: asset.baselineAssetSize,
       diff: asset.sizeDiff,
@@ -57,6 +59,7 @@ export const createReportData = ({
       name: asset.assetName,
       isKeyAsset: asset.isKeyAsset,
       hasTarget: asset.hasTarget,
+      hasThreshold: asset.hasThreshold,
       size: asset.candidateAssetSize,
       baselineSize: asset.baselineAssetSize,
       diff: asset.sizeDiff,
@@ -72,6 +75,7 @@ export const createReportData = ({
       name: asset.assetName,
       isKeyAsset: asset.isKeyAsset,
       hasTarget: asset.hasTarget,
+      hasThreshold: asset.hasThreshold,
       size: asset.candidateAssetSize,
       baselineSize: asset.baselineAssetSize,
       diff: asset.sizeDiff,


### PR DESCRIPTION
Allow product teams to specify an explicit a target than shouldn't be exceeded, and to specify an explicit threshold against the baseline target, in addition to the current explicit target and threshold.